### PR TITLE
fix(syncer): Fix GetModuleByName deadlock

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -163,7 +163,7 @@ func (s *Syncer) GetModuleByName(ident, namespace, name string) *tenant.Module {
 	s.job.lock.RLock()
 	defer s.job.lock.RUnlock()
 
-	tnt := s.TenantOverview(ident)
+	tnt := s.job.overviews[ident]
 	if tnt == nil {
 		return nil
 	}


### PR DESCRIPTION
`GetModuleByName` acquires a read lock and then  calls `TenantOverview` which also acquires a ReadLock. 

`State` is called every second and acquires a WriteLock. 

If `GetModuleByName` acquires a ReadLock and State awaits a WriteLock before `TenantOverview` is called (within the GetModuleByName method) then State is awaiting GetModuleByName which called TenantOverview which is awaiting State. 

This change removes the need to call TenantOverview from within GetModuleByName remove the possibility for this deadlock.