### PR TITLE
feat(auth): API Authorization Cache

### DIFF
--- a/auth/authorizer_test.go
+++ b/auth/authorizer_test.go
@@ -1,0 +1,360 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/suborbital/e2core/common"
+)
+
+type CompareAssertionFunc[T any] func(t *testing.T, actual T) bool
+
+func TestAuthorizerCache_ConcurrentRequests(t *testing.T) {
+	type args struct {
+		token string
+	}
+
+	type test struct {
+		name       string
+		args       args
+		handler    http.HandlerFunc
+		assertOpts CompareAssertionFunc[uint64]
+		assertErr  assert.ErrorAssertionFunc
+	}
+
+	tests := []test{
+		{
+			name: "Ensure duplicate requests are pipelined",
+			args: args{
+				token: "token",
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(&AuthorizationResponse{
+					Identity:    "tester",
+					Account:     "acct",
+					Environment: "env",
+					Tenant:      "123",
+					Path:        "namespace/mod",
+				})
+			},
+			assertOpts: func(t *testing.T, actual uint64) bool {
+				return assert.Equal(t, uint64(1), actual)
+			},
+			assertErr: func(_ assert.TestingT, err error, _ ...interface{}) bool {
+				return err == nil
+			},
+		},
+		{
+			name: "Ensure non-credentialed requests are not dispatched",
+			args: args{
+				token: "",
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(&AuthorizationResponse{})
+			},
+			assertOpts: func(t *testing.T, actual uint64) bool {
+				return assert.Equal(t, uint64(0), actual)
+			},
+			assertErr: func(_ assert.TestingT, err error, _ ...interface{}) bool {
+				return common.IsError(err, common.ErrAccess)
+			},
+		},
+		{
+			name: "Ensure denied requests return ErrAccess",
+			args: args{
+				token: "token",
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			},
+			// Although each request is effectively sent at the same time this is ultimately up to the scheduler.
+			// We allow for up to 10% of the requests to go through to avoid flakiness in CI environments.
+			assertOpts: func(t *testing.T, actual uint64) bool {
+				return assert.LessOrEqual(t, actual, uint64(100))
+			},
+			assertErr: func(_ assert.TestingT, err error, _ ...interface{}) bool {
+				return common.IsError(err, common.ErrAccess) || common.IsError(err, common.ErrCanceled)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		var opts uint64 = 0
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddUint64(&opts, 1)
+			tc.handler(w, r)
+		}))
+
+		authorizer := &AuthzClient{
+			httpClient: svr.Client(),
+			location:   svr.URL,
+			cache:      newAuthorizationCache(common.StableTime(time.Now()), 10*time.Minute),
+		}
+
+		var err error
+		wg := sync.WaitGroup{}
+		for i := 0; i < 1000; i++ {
+			wg.Add(1)
+			go func() {
+				_, err = authorizer.Authorize(NewAccessToken(tc.args.token), "env.app", "namespace", "mod")
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+
+		svr.Close()
+
+		tc.assertErr(t, err)
+		tc.assertOpts(t, opts)
+	}
+}
+
+func TestAuthorizerCache(t *testing.T) {
+	type args struct {
+		token      string
+		identifier string
+		namespace  string
+		mod        string
+	}
+
+	type test struct {
+		name       string
+		args       []args
+		handler    http.HandlerFunc
+		assertOpts CompareAssertionFunc[uint64]
+		wantErr    error
+	}
+
+	tests := []test{
+		{
+			name: "Ensure each unique request is dispatched",
+			args: []args{
+				{
+					token:      "token",
+					identifier: "env.123",
+					namespace:  "default",
+					mod:        "mod",
+				},
+				{
+					token:      "token2",
+					identifier: "env.123",
+					namespace:  "default",
+					mod:        "mod",
+				},
+				{
+					token:      "token",
+					identifier: "env.abc",
+					namespace:  "default",
+					mod:        "mod",
+				},
+				{
+					token:      "token",
+					identifier: "env.123",
+					namespace:  "not-default",
+					mod:        "mod",
+				},
+				{
+					token:      "token",
+					identifier: "env.123",
+					namespace:  "default",
+					mod:        "mod-2",
+				},
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				var authzReq *AuthorizationRequest
+				_ = json.NewDecoder(r.Body).Decode(&authzReq)
+				_ = json.NewEncoder(w).Encode(&AuthorizationResponse{
+					Identity:    "tester",
+					Account:     "acct",
+					Environment: authzReq.Resource[0],
+					Tenant:      authzReq.Resource[1],
+					Path:        strings.Join(authzReq.Resource[2:], "/"),
+				})
+			},
+			assertOpts: func(t *testing.T, actual uint64) bool {
+				return assert.Equal(t, uint64(5), actual)
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Ensure failed requests aren't cached",
+			args: []args{
+				{
+					token:      "token",
+					identifier: "env.123",
+					namespace:  "default",
+					mod:        "mod",
+				},
+				{
+					token:      "token",
+					identifier: "env.123",
+					namespace:  "default",
+					mod:        "mod",
+				},
+				{
+					token:      "token",
+					identifier: "env.123",
+					namespace:  "default",
+					mod:        "mod",
+				},
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			},
+			assertOpts: func(t *testing.T, actual uint64) bool {
+				return assert.Equal(t, uint64(3), actual)
+			},
+			wantErr: common.ErrAccess,
+		},
+		{
+			name: "Ensure success after failure",
+			args: []args{
+				{
+					token:      "token",
+					identifier: "env.123",
+					namespace:  "default",
+					mod:        "mod",
+				},
+				{
+					token:      "denied",
+					identifier: "env.123",
+					namespace:  "default",
+					mod:        "mod",
+				},
+				{
+					token:      "token",
+					identifier: "env.123",
+					namespace:  "default",
+					mod:        "mod",
+				},
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				token := ExtractAccessToken(r.Header)
+				if token.Value() == "denied" {
+					w.WriteHeader(http.StatusUnauthorized)
+				} else {
+					w.WriteHeader(http.StatusOK)
+					var authzReq *AuthorizationRequest
+					_ = json.NewDecoder(r.Body).Decode(&authzReq)
+					_ = json.NewEncoder(w).Encode(&AuthorizationResponse{
+						Identity:    "tester",
+						Account:     "acct",
+						Environment: authzReq.Resource[0],
+						Tenant:      authzReq.Resource[1],
+						Path:        strings.Join(authzReq.Resource[2:], "/"),
+					})
+				}
+			},
+			assertOpts: func(t *testing.T, actual uint64) bool {
+				return assert.Equal(t, uint64(2), actual)
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		var opts uint64 = 0
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddUint64(&opts, 1)
+			tc.handler(w, r)
+		}))
+
+		authorizer := &AuthzClient{
+			httpClient: svr.Client(),
+			location:   svr.URL,
+			cache:      newAuthorizationCache(common.StableTime(time.Now()), 10*time.Minute),
+		}
+
+		var err error
+		for _, arg := range tc.args {
+			_, err = authorizer.Authorize(NewAccessToken(arg.token), arg.identifier, arg.namespace, arg.mod)
+		}
+
+		svr.Close()
+
+		assert.ErrorIs(t, err, tc.wantErr)
+		assert.True(t, tc.assertOpts(t, opts))
+	}
+}
+
+func TestAuthorizerCache_ExpiringEntry(t *testing.T) {
+	type args struct {
+		ttl time.Duration
+	}
+
+	type test struct {
+		name       string
+		args       args
+		handler    http.HandlerFunc
+		assertOpts CompareAssertionFunc[uint64]
+		wantErr    error
+	}
+
+	tests := []test{
+		{
+			name: "Ensure expired tokens are refreshed",
+			args: args{ttl: 1 * time.Second},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(&AuthorizationResponse{
+					Identity:    "tester",
+					Account:     "acct",
+					Environment: "env",
+					Tenant:      "123",
+					Path:        "namespace/mod",
+				})
+			},
+			assertOpts: func(t *testing.T, actual uint64) bool {
+				return assert.Equal(t, uint64(2), actual)
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		var opts uint64 = 0
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddUint64(&opts, 1)
+			tc.handler(w, r)
+		}))
+
+		clock := common.StableTime(time.Now())
+
+		authzCache := newAuthorizationCache(clock, 10*time.Minute)
+		authzCache.clock = clock
+
+		authorizer := &AuthzClient{
+			httpClient: svr.Client(),
+			location:   svr.URL,
+			cache:      authzCache,
+		}
+
+		// 1 auth op
+		_, err := authorizer.Authorize(NewAccessToken("token"), "env.app", "namespace", "mod")
+		_, err = authorizer.Authorize(NewAccessToken("token"), "env.app", "namespace", "mod")
+		_, err = authorizer.Authorize(NewAccessToken("token"), "env.app", "namespace", "mod")
+
+		clock.Tick(authzCache.ttl + 1*time.Second)
+
+		// 2 auth op
+		_, err = authorizer.Authorize(NewAccessToken("token"), "env.app", "namespace", "mod")
+		_, err = authorizer.Authorize(NewAccessToken("token"), "env.app", "namespace", "mod")
+		_, err = authorizer.Authorize(NewAccessToken("token"), "env.app", "namespace", "mod")
+
+		svr.Close()
+
+		assert.ErrorIs(t, err, tc.wantErr)
+		assert.True(t, tc.assertOpts(t, opts))
+	}
+}

--- a/auth/cache.go
+++ b/auth/cache.go
@@ -1,0 +1,79 @@
+package auth
+
+import (
+	"time"
+
+	"github.com/suborbital/e2core/common"
+)
+
+// NewAuthorizationCache creates a new AuthorizationCache
+func NewAuthorizationCache(ttl time.Duration) *AuthorizationCache {
+	return newAuthorizationCache(common.SystemTime(), ttl)
+}
+
+// NewAuthorizationCache creates a new AuthorizationCache
+func newAuthorizationCache(clock common.Clock, ttl time.Duration) *AuthorizationCache {
+	store := common.NewTreeStore[*expiringContext]()
+	cache := common.NewLoadingCache[*expiringContext](store)
+
+	return &AuthorizationCache{
+		clock: clock,
+		ttl:   ttl,
+		cache: cache,
+	}
+}
+
+// AuthorizationCache caches authorization successful policy decisions for up to 10 minutes.
+type AuthorizationCache struct {
+	clock common.Clock
+	ttl   time.Duration
+	cache *common.LoadingCache[*expiringContext]
+}
+
+// Get fetches a cached result if present; otherwise it executes newFunc to obtain the result.
+func (cache AuthorizationCache) Get(key string, newFunc func() (*AuthorizationContext, error)) (*AuthorizationContext, error) {
+	// register newFunc if not previously known
+	if !cache.cache.Check(key) {
+		_ = cache.cache.Put(key, cache.loadingFunc(newFunc))
+	}
+
+	// return promptly if entry is found and valid
+	entry := cache.cache.Get(key)
+	if entry.Value != nil {
+		if entry.Value.exp.After(cache.clock.Now()) {
+			return entry.Value.ctx, entry.Error
+		}
+		// entry found but expired, refresh and await result
+		_ = cache.cache.Refresh(key)
+		entry = cache.cache.Get(key)
+	}
+
+	if entry.Error != nil {
+		// reset entry state so subsequent requests run
+		cache.cache.Replace(key, cache.loadingFunc(newFunc))
+		return nil, entry.Error
+	}
+
+	return entry.Value.ctx, entry.Error
+}
+
+// loadingFun wraps a loader func with an expiringContext loader
+func (cache AuthorizationCache) loadingFunc(inner func() (*AuthorizationContext, error)) func() (*expiringContext, error) {
+	return func() (*expiringContext, error) {
+		ctx, err := inner()
+		if err != nil {
+			return nil, err
+		}
+
+		return &expiringContext{
+			exp: cache.clock.In(cache.ttl),
+			ctx: ctx,
+		}, nil
+	}
+}
+
+// expiringContext wraps a value with an expiry
+type expiringContext struct {
+	exp time.Time
+	ctx *AuthorizationContext
+}

--- a/common/atomic.go
+++ b/common/atomic.go
@@ -1,0 +1,31 @@
+package common
+
+import "sync/atomic"
+
+// NewAtomicReference returns a new AtomicReference with an initial value.
+func NewAtomicReference[T any](init T) *AtomicReference[T] {
+	ref := new(AtomicReference[T])
+	ref.Store(init)
+
+	return ref
+}
+
+// AtomicReference is a Generic wrapper for atomic.Value
+type AtomicReference[T any] struct {
+	value atomic.Value
+}
+
+// Load wraps atomic.Load
+func (ref *AtomicReference[T]) Load() T {
+	return ref.value.Load().(T)
+}
+
+// Store wraps atomic.Store
+func (ref *AtomicReference[T]) Store(value T) {
+	ref.value.Store(value)
+}
+
+// Swap wraps atomic.Swap
+func (ref *AtomicReference[T]) Swap(value T) T {
+	return ref.value.Swap(value).(T)
+}

--- a/common/cache.go
+++ b/common/cache.go
@@ -1,0 +1,317 @@
+package common
+
+import (
+	"sync"
+
+	art "github.com/plar/go-adaptive-radix-tree"
+)
+
+const (
+	// EntryInit marks a cache entry as initialized but not yet populated.
+	EntryInit EntryState = iota
+	// EntryPending indicates the cache entry is the process of being updated.
+	EntryPending
+	// EntryError indicates the last attempt to update a cache entry failed.
+	EntryError
+	// EntryCanceled indicates an update was attempted but canceled before completing.
+	EntryCanceled
+	// EntryReady indicates the cache entry is ready for use.
+	EntryReady
+)
+
+type (
+	// EntryState represents the current state of a CacheEntry.
+	EntryState uint8
+
+	// Value is an immutable snapshot of a CacheEntry's state.
+	Value[V any] struct {
+		State EntryState
+		Value V
+		Error error
+	}
+
+	// Entry represents a cached entry.
+	Entry[V any] struct {
+		cond        *sync.Cond
+		state       EntryState
+		loadingFunc func() (V, error)
+		value       V
+		err         error
+	}
+
+	// LoadingCache is an in-memory key-value store.
+	// Value lifecycles are managed by the cache until their key is dropped.
+	LoadingCache[V any] struct {
+		lock    *sync.Mutex
+		entries CacheStore[V]
+	}
+)
+
+type CacheStore[V any] interface {
+	Get(string) *Entry[V]
+	Put(string, *Entry[V])
+	Delete(string)
+}
+
+func NewMapStore[V any]() MapStore[V] {
+	return MapStore[V]{
+		store: make(map[string]*Entry[V]),
+	}
+}
+
+type MapStore[V any] struct {
+	store map[string]*Entry[V]
+}
+
+func (store MapStore[V]) Get(key string) *Entry[V] {
+	return store.store[key]
+}
+
+func (store MapStore[V]) Put(key string, val *Entry[V]) {
+	store.store[key] = val
+}
+
+func (store MapStore[V]) Delete(key string) {
+	delete(store.store, key)
+}
+
+func NewTreeStore[V any]() TreeStore[V] {
+	return TreeStore[V]{
+		store: art.New(),
+	}
+}
+
+type TreeStore[V any] struct {
+	store art.Tree
+}
+
+func (store TreeStore[V]) Get(key string) *Entry[V] {
+	if val, ok := store.store.Search(art.Key(key)); ok {
+		return val.(*Entry[V])
+	}
+
+	return nil
+}
+
+func (store TreeStore[V]) Put(key string, val *Entry[V]) {
+	store.store.Insert(art.Key(key), val)
+}
+
+func (store TreeStore[V]) Delete(key string) {
+	store.store.Delete(art.Key(key))
+}
+
+// String returns EntryState as a string.
+func (state EntryState) String() string {
+	var name string
+	switch state {
+	case EntryInit:
+		name = "[EntryState=INIT]"
+	case EntryPending:
+		name = "[EntryState=PENDING]"
+	case EntryError:
+		name = "[EntryState=ERROR]"
+	case EntryCanceled:
+		name = "[EntryState=CANCELED]"
+	case EntryReady:
+		name = "[EntryState=READY]"
+	}
+
+	return name
+}
+
+// NewLoadingCache returns a new instance of LoadingCache[V].
+func NewLoadingCache[V any](store CacheStore[V]) *LoadingCache[V] {
+	return &LoadingCache[V]{
+		lock:    new(sync.Mutex),
+		entries: store,
+	}
+}
+
+// Get the Entry associated with Key, loading a new instance if unknown.
+// If Entry exists and is EntryPending this call parks the caller until the update is complete.
+func (cache *LoadingCache[V]) Get(key string) Value[V] {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+
+	entry := cache.entries.Get(key)
+	if entry == nil {
+		return Value[V]{
+			State: EntryError,
+			Error: DoesNotExistError("[LoadingCache] Get"),
+		}
+	}
+
+	switch entry.state {
+	case EntryError:
+		return Value[V]{
+			State: entry.state,
+			Value: entry.value,
+			Error: entry.err,
+		}
+	case EntryInit:
+		asyncLoad(entry)
+		fallthrough
+	case EntryPending:
+		// park routine until update completes
+		for entry.state == EntryPending {
+			entry.cond.Wait()
+		}
+		fallthrough
+	default: // Ready | Failed | Canceled
+		return Value[V]{
+			State: entry.state,
+			Value: entry.value,
+			Error: entry.err,
+		}
+	}
+}
+
+// Check returns true if a key is present in the cache, else false.
+func (cache *LoadingCache[V]) Check(key string) bool {
+	cache.lock.Lock()
+	found := cache.entries.Get(key) != nil
+	cache.lock.Unlock()
+
+	return found
+}
+
+// Put creates a new entry in the LoadingCache using the supplied loadingFunc.
+// All entries are loaded lazily meaning loadingFunc is not invoked until LoadingCache.Get(key) is called.
+func (cache *LoadingCache[V]) Put(key string, loadingFunc func() (V, error)) error {
+	// Optimistic look up to avoid lock contention.
+	entry := cache.entries.Get(key)
+	if entry != nil {
+		return DuplicateEntryError("[LoadingCache] Put")
+	}
+
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+
+	// verify observed state is still valid
+	entry = cache.entries.Get(key)
+	if entry != nil {
+		return DuplicateEntryError("[LoadingCache] Put")
+	}
+
+	cache.entries.Put(key, &Entry[V]{
+		cond:        sync.NewCond(cache.lock),
+		state:       EntryInit,
+		loadingFunc: loadingFunc})
+
+	return nil
+}
+
+// Replace overwrites the loadingFunc for an existing key.
+// If there is no key present a new one will be created.
+func (cache *LoadingCache[V]) Replace(key string, loadingFunc func() (V, error)) {
+	cache.lock.Lock()
+
+	entry := cache.entries.Get(key)
+	if entry == nil {
+		cache.entries.Put(key, &Entry[V]{
+			cond:        sync.NewCond(cache.lock),
+			state:       EntryInit,
+			loadingFunc: loadingFunc,
+		})
+	} else {
+		entry.loadingFunc = loadingFunc
+		entry.state = EntryInit
+	}
+
+	cache.lock.Unlock()
+}
+
+// Refresh updates a cache Entry asynchronously.
+// Calling LoadingCache.Get(key) immediately allows the caller to await the result.
+func (cache *LoadingCache[V]) Refresh(key string) error {
+	cache.lock.Lock()
+
+	entry := cache.entries.Get(key)
+	if entry == nil {
+		cache.lock.Unlock()
+		return DoesNotExistError("[LoadingCache] Pending")
+	}
+
+	asyncLoad(entry)
+	cache.lock.Unlock()
+
+	return nil
+}
+
+// Cancel cancels an update and notifies all watchers.
+func (cache *LoadingCache[V]) Cancel(key string) {
+	cache.lock.Lock()
+
+	entry := cache.entries.Get(key)
+	if entry == nil {
+		cache.lock.Unlock()
+		return
+	}
+
+	if entry.state <= EntryPending {
+		entry.err = ErrCanceled
+		entry.state = EntryCanceled
+	}
+
+	cache.lock.Unlock()
+	entry.cond.Broadcast()
+}
+
+// Drop removes the entry associated with key from the cache.
+func (cache *LoadingCache[V]) Drop(key string) {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+
+	entry := cache.entries.Get(key)
+	if entry == nil {
+		return
+	}
+
+	cache.entries.Delete(key)
+	// ensure asyncLoad does not repopulate entry on completion.
+	if entry.state == EntryPending {
+		entry.state = EntryCanceled
+	}
+
+	entry.cond.Broadcast()
+}
+
+// Cache lock must be held when calling asyncLoad.
+func asyncLoad[V any](entry *Entry[V]) {
+	if entry == nil {
+		return
+	}
+
+	entry.state = EntryPending
+
+	go func() {
+		// execute potentially expensive operation without holding lock
+		value, err := entry.loadingFunc()
+
+		// reacquire lock
+		entry.cond.L.Lock()
+
+		if entry.state == EntryCanceled {
+			// no-op, throw-away results
+			entry.err = ErrCanceled
+			entry.cond.L.Unlock()
+			return
+		}
+
+		// do not override value on err
+		if err == nil {
+			entry.state = EntryReady
+			entry.value = value
+			entry.err = err
+		} else {
+			entry.state = EntryError
+			entry.err = err
+		}
+
+		// notify watchers
+		entry.cond.Broadcast()
+
+		entry.cond.L.Unlock()
+	}()
+}

--- a/common/cache_test.go
+++ b/common/cache_test.go
@@ -1,0 +1,463 @@
+package common
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadingCache_Get(t *testing.T) {
+	type args struct {
+		putKey     string
+		getKey     string
+		failLoader bool
+	}
+
+	type test struct {
+		name string
+		args args
+		want Value[int]
+	}
+
+	tests := []test{
+		{
+			name: "Test LoadingCache Get",
+			args: args{
+				putKey: "count",
+				getKey: "count",
+			},
+			want: Value[int]{
+				State: EntryReady,
+				Value: 1,
+				Error: nil,
+			},
+		},
+		{
+			name: "Test LoadingCache Get invalid key",
+			args: args{
+				putKey: "count",
+				getKey: "invalid",
+			},
+			want: Value[int]{
+				State: EntryError,
+				Value: 0,
+				Error: ErrNotExists,
+			},
+		},
+		{
+			name: "Test LoadingCache failed load operation",
+			args: args{
+				putKey:     "count",
+				getKey:     "count",
+				failLoader: true,
+			},
+			want: Value[int]{
+				State: EntryError,
+				Value: 0,
+				Error: ErrNotExists,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		// instructs the loader function to complete
+		complete := make(chan struct{}, 1)
+		// signals the test to proceed
+		step := make(chan struct{}, 1)
+
+		cache := NewLoadingCache[int](NewTreeStore[int]())
+		count := 0
+
+		cache.Put(tc.args.putKey, func() (int, error) {
+			<-complete
+			count += 1
+			if tc.args.failLoader {
+				// value should not be overwritten on failure to load
+				return -1, tc.want.Error
+			}
+
+			return count, nil
+
+		})
+
+		var value Value[int]
+		go func() {
+			step <- struct{}{}
+			value = cache.Get(tc.args.getKey)
+
+			assert.Equal(t, tc.want.State, value.State)
+			assert.Equal(t, tc.want.Value, value.Value)
+			assert.ErrorIs(t, value.Error, tc.want.Error)
+
+			step <- struct{}{}
+		}()
+
+		<-step
+
+		// Ensure unrelated keys aren't blocked by loading func
+		other := uuid.NewString()
+		cache.Put(other, func() (int, error) {
+			return -1, nil
+		})
+		assert.Equal(t, -1, cache.Get(other).Value)
+
+		// cache.Get should be blocked awaiting a response
+		assert.Zero(t, value.Value)
+
+		// complete loader func
+		complete <- struct{}{}
+		close(complete)
+
+		<-step
+
+		// should not invoke loader again; deadlock detector will panic since there are no more references to complete
+		value = cache.Get(tc.args.getKey)
+
+		assert.Equal(t, tc.want.Value, value.Value)
+		assert.Equal(t, tc.want.State, value.State)
+		assert.ErrorIs(t, value.Error, tc.want.Error)
+	}
+}
+
+func TestLoadingCache_Refresh(t *testing.T) {
+	type args struct {
+		putKey     string
+		getKey     string
+		failLoader bool
+	}
+
+	type test struct {
+		name string
+		args args
+		want Value[int]
+	}
+
+	tests := []test{
+		{
+			name: "Test LoadingCache Get",
+			args: args{
+				putKey: "count",
+				getKey: "count",
+			},
+			want: Value[int]{
+				State: EntryReady,
+				Value: 2,
+				Error: nil,
+			},
+		},
+		{
+			name: "Test LoadingCache Get invalid key",
+			args: args{
+				putKey: "count",
+				getKey: "invalid",
+			},
+			want: Value[int]{
+				State: EntryError,
+				Value: 0,
+				Error: ErrNotExists,
+			},
+		},
+		{
+			name: "Test LoadingCache failed load operation",
+			args: args{
+				putKey:     "count",
+				getKey:     "count",
+				failLoader: true,
+			},
+			want: Value[int]{
+				State: EntryError,
+				Value: 1,
+				Error: ErrNotExists,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		// instructs the loader function to complete
+		complete := make(chan struct{}, 1)
+		// signals the test to proceed
+		step := make(chan struct{}, 1)
+
+		cache := NewLoadingCache[int](NewTreeStore[int]())
+
+		count := -2
+		cache.Put(tc.args.putKey, func() (int, error) {
+			if count == -2 {
+				count = 1
+				return count, nil
+			}
+
+			<-complete
+
+			count += 1
+			if tc.args.failLoader {
+				// value should not be overwritten on failure to load
+				return -1, tc.want.Error
+			}
+
+			return count, nil
+
+		})
+
+		// value initialization should always succeed
+		value := cache.Get(tc.args.putKey)
+
+		go func() {
+			step <- struct{}{}
+			_ = cache.Refresh(tc.args.putKey)
+		}()
+
+		<-step
+
+		go func() {
+			step <- struct{}{}
+			value = cache.Get(tc.args.getKey)
+		}()
+
+		<-step
+		close(step)
+
+		complete <- struct{}{}
+		close(complete)
+
+		value = cache.Get(tc.args.getKey)
+		assert.Equal(t, tc.want.State, value.State)
+		assert.Equal(t, tc.want.Value, value.Value)
+		assert.ErrorIs(t, value.Error, tc.want.Error)
+	}
+}
+
+func TestLoadingCache_Cancel(t *testing.T) {
+	type args struct {
+		putKey     string
+		getKey     string
+		failLoader bool
+	}
+
+	type test struct {
+		name string
+		args args
+		want Value[int]
+	}
+
+	tests := []test{
+		{
+			name: "Test LoadingCache Cancel",
+			args: args{
+				putKey: "count",
+				getKey: "count",
+			},
+			want: Value[int]{
+				State: EntryCanceled,
+				Value: 0,
+				Error: ErrCanceled,
+			},
+		},
+		{
+			name: "Test LoadingCache Cancel invalid key",
+			args: args{
+				putKey: "count",
+				getKey: "invalid",
+			},
+			want: Value[int]{
+				State: EntryError,
+				Value: 0,
+				Error: ErrNotExists,
+			},
+		},
+		{
+			name: "Test LoadingCache failed load operation",
+			args: args{
+				putKey:     "count",
+				getKey:     "count",
+				failLoader: true,
+			},
+			want: Value[int]{
+				State: EntryCanceled,
+				Value: 0,
+				Error: ErrCanceled,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		result := make(chan Value[int], 1)
+		// instructs the loader function to complete
+		complete := make(chan struct{}, 1)
+		// signals the test to proceed
+		step := make(chan struct{}, 1)
+
+		cache := NewLoadingCache[int](NewTreeStore[int]())
+
+		cache.Put(tc.args.putKey, func() (int, error) {
+			<-complete
+			if tc.args.failLoader {
+				// value should not be overwritten on failure to load
+				return -1, tc.want.Error
+			}
+
+			return 2, nil
+		})
+
+		go func() {
+			step <- struct{}{}
+			result <- cache.Get(tc.args.getKey)
+		}()
+
+		// cache.Get() parked, load func still blocked
+		<-step
+
+		// wake up cache.Get(key) watchers, cancel update
+		cache.Cancel(tc.args.getKey)
+		value := <-result
+
+		close(step)
+		// close unblocks receiver
+		close(complete)
+		close(result)
+
+		assert.Equal(t, tc.want.State, value.State)
+		assert.Equal(t, tc.want.Value, value.Value)
+		assert.ErrorIs(t, value.Error, tc.want.Error)
+	}
+}
+
+func TestLoadingCache_Drop(t *testing.T) {
+	type args struct {
+		putKey     string
+		getKey     string
+		failLoader bool
+	}
+
+	type test struct {
+		name string
+		args args
+		want Value[int]
+	}
+
+	tests := []test{
+		{
+			name: "Test LoadingCache Drop",
+			args: args{
+				putKey: "count",
+				getKey: "count",
+			},
+			want: Value[int]{
+				State: EntryCanceled,
+				Value: 0,
+				Error: nil,
+			},
+		},
+		{
+			name: "Test LoadingCache Drop, invalid key",
+			args: args{
+				putKey: "count",
+				getKey: "invalid",
+			},
+			want: Value[int]{
+				State: EntryError,
+				Value: 0,
+				Error: ErrNotExists,
+			},
+		},
+		{
+			name: "Test LoadingCache Drop, failed load operation",
+			args: args{
+				putKey:     "count",
+				getKey:     "count",
+				failLoader: true,
+			},
+			want: Value[int]{
+				State: EntryCanceled,
+				Value: 0,
+				Error: nil,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		// signals async cache.Get() has returned
+		result := make(chan Value[int], 1)
+		// instructs the loader function to complete
+		complete := make(chan struct{}, 1)
+		// signals the test to proceed
+		step := make(chan struct{}, 1)
+
+		cache := NewLoadingCache[int](NewTreeStore[int]())
+
+		cache.Put(tc.args.putKey, func() (int, error) {
+			<-complete
+			if tc.args.failLoader {
+				// value should not be overwritten on failure to load
+				return -1, tc.want.Error
+			}
+
+			return 2, nil
+		})
+
+		go func() {
+			step <- struct{}{}
+			result <- cache.Get(tc.args.getKey)
+		}()
+
+		// cache.Get() scheduled, load func still blocked
+		<-step
+		close(step)
+
+		// wake up cache.Get(key) watchers, cancel update
+		cache.Drop(tc.args.getKey)
+
+		// pending request should be canceled
+		value := <-result
+		close(result)
+
+		assert.Equal(t, tc.want.State, value.State)
+		assert.Equal(t, tc.want.Value, value.Value)
+		assert.ErrorIs(t, value.Error, tc.want.Error)
+
+		// unblock loader func
+		complete <- struct{}{}
+		close(complete)
+
+		// subsequent requests should fail because key is no longer present
+		value = cache.Get(tc.args.getKey)
+		assert.Equal(t, EntryError, value.State)
+		assert.Equal(t, 0, value.Value)
+		assert.ErrorIs(t, value.Error, ErrNotExists)
+	}
+}
+
+func TestLoadingCache_DuplicateRegistration(t *testing.T) {
+	wg := sync.WaitGroup{}
+	// synchronized collection to capture response
+	errs := make(chan error, 10)
+
+	cache := NewLoadingCache[int](NewTreeStore[int]())
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			errs <- cache.Put("key", func() (int, error) {
+				return 1, nil
+			})
+			wg.Done()
+		}()
+	}
+
+	// wait for all routines to complete
+	wg.Wait()
+	close(errs)
+
+	errCount := 0
+	for err := range errs {
+		// record presence of target error
+		if IsError(err, ErrExists) {
+			errCount += 1
+		}
+	}
+
+	// ensure all but one put failed with the correct error type
+	assert.Equal(t, 9, errCount)
+}

--- a/common/clock.go
+++ b/common/clock.go
@@ -1,0 +1,54 @@
+package common
+
+import "time"
+
+type Clock interface {
+	// Now returns the current clock time.
+	Now() time.Time
+	// In returns the clock time plus time.Duration
+	In(time.Duration) time.Time
+}
+
+// SystemTime is a clock facade on time.Time.
+func SystemTime() Clock {
+	return &systemClock{}
+}
+
+type systemClock struct{}
+
+func (clock *systemClock) Now() time.Time {
+	return time.Now()
+}
+
+func (clock *systemClock) In(duration time.Duration) time.Time {
+	return time.Now().Add(duration)
+}
+
+type StableClock interface {
+	Clock
+	// Tick increments StableTime by duration
+	Tick(duration time.Duration)
+}
+
+// StableTime is a clock which must be manually updated.
+func StableTime(epoch time.Time) StableClock {
+	return &stableClock{
+		epoch: NewAtomicReference(epoch),
+	}
+}
+
+type stableClock struct {
+	epoch *AtomicReference[time.Time]
+}
+
+func (clock *stableClock) Now() time.Time {
+	return clock.epoch.Load()
+}
+
+func (clock *stableClock) In(duration time.Duration) time.Time {
+	return clock.epoch.Load().Add(duration)
+}
+
+func (clock *stableClock) Tick(duration time.Duration) {
+	clock.epoch.Swap(clock.epoch.Load().Add(duration))
+}

--- a/common/error.go
+++ b/common/error.go
@@ -1,0 +1,65 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrAccess    = errors.New("unauthorized")
+	ErrExists    = errors.New("already exists")
+	ErrNotExists = errors.New("does not exist")
+	ErrCanceled  = errors.New("execution canceled")
+	ErrInvalid   = errors.New("invalid argument")
+	ErrLimit     = errors.New("too many requests")
+)
+
+func AuthorizationError(detail string, args ...any) error {
+	return Error(ErrAccess, detail, args...)
+}
+
+func DuplicateEntryError(detail string, args ...any) error {
+	return Error(ErrExists, detail, args...)
+}
+
+func DoesNotExistError(detail string, args ...any) error {
+	return Error(ErrNotExists, detail, args...)
+}
+
+func InvalidArgument(detail string, args ...any) error {
+	return Error(ErrInvalid, detail, args...)
+}
+
+func TooManyRequests(detail string, args ...any) error {
+	return Error(ErrLimit, detail, args...)
+}
+
+func IsError(err error, target error) bool {
+	if err == nil && target != nil {
+		return false
+	}
+
+	return errors.Is(err, target)
+}
+
+func Error(err error, detail string, args ...any) error {
+	if err == nil {
+		return nil
+	}
+
+	return errors.Wrap(err, fmt.Sprintf(detail, args...))
+}
+
+func Must(err error) {
+	if err != nil {
+		panic(Error(err, "Error must not be raised"))
+	}
+}
+
+func MustReturn[T any](value T, err error) T {
+	if err != nil {
+		panic(Error(err, "Error must not be raised"))
+	}
+	return value
+}

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/nats-io/nkeys v0.3.0 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
+	github.com/plar/go-adaptive-radix-tree v1.0.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/second-state/WasmEdge-go v0.11.0 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,8 @@ github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFu
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/plar/go-adaptive-radix-tree v1.0.4 h1:Ucd8R6RH2E7RW8ZtDKrsWyOD3paG2qqJO0I20WQ8oWQ=
+github.com/plar/go-adaptive-radix-tree v1.0.4/go.mod h1:Ot8d28EII3i7Lv4PSvBlF8ejiD/CtRYDuPsySJbSaK8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/options/options.go
+++ b/options/options.go
@@ -2,6 +2,8 @@ package options
 
 import (
 	"context"
+	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sethvargo/go-envconfig"
@@ -20,18 +22,19 @@ const (
 type Options struct {
 	logger *vlog.Logger
 
-	Features         []string     `env:"E2CORE_API_FEATURES"`
-	BundlePath       string       `env:"E2CORE_BUNDLE_PATH"`
-	RunSchedules     *bool        `env:"E2CORE_RUN_SCHEDULES,default=true"`
-	ControlPlane     string       `env:"E2CORE_CONTROL_PLANE"`
-	UpstreamAddress  string       `env:"E2CORE_UPSTREAM_ADDRESS"`
-	EnvironmentToken string       `env:"E2CORE_ENV_TOKEN"`
-	StaticPeers      string       `env:"E2CORE_PEERS"`
-	AppName          string       `env:"E2CORE_APP_NAME,default=E2Core"`
-	Domain           string       `env:"E2CORE_DOMAIN"`
-	HTTPPort         int          `env:"E2CORE_HTTP_PORT,default=8080"`
-	TLSPort          int          `env:"E2CORE_TLS_PORT,default=443"`
-	TracerConfig     TracerConfig `env:",prefix=E2CORE_TRACER_"`
+	Features         []string      `env:"E2CORE_API_FEATURES"`
+	BundlePath       string        `env:"E2CORE_BUNDLE_PATH"`
+	RunSchedules     *bool         `env:"E2CORE_RUN_SCHEDULES,default=true"`
+	ControlPlane     string        `env:"E2CORE_CONTROL_PLANE"`
+	AuthCacheTTL     time.Duration `env:"E2CORE_AUTH_CACHE_TTL,default=10m"`
+	UpstreamAddress  string        `env:"E2CORE_UPSTREAM_ADDRESS"`
+	EnvironmentToken string        `env:"E2CORE_ENV_TOKEN"`
+	StaticPeers      string        `env:"E2CORE_PEERS"`
+	AppName          string        `env:"E2CORE_APP_NAME,default=E2Core"`
+	Domain           string        `env:"E2CORE_DOMAIN"`
+	HTTPPort         int           `env:"E2CORE_HTTP_PORT,default=8080"`
+	TLSPort          int           `env:"E2CORE_TLS_PORT,default=443"`
+	TracerConfig     TracerConfig  `env:",prefix=E2CORE_TRACER_"`
 }
 
 // TracerConfig holds values specific to setting up the tracer. It's only used in proxy mode. All configuration options
@@ -136,7 +139,8 @@ func (o *Options) finalize(prefix string) {
 		return
 	}
 
-	o.ControlPlane = envOpts.ControlPlane
+	o.ControlPlane = strings.TrimSuffix(envOpts.ControlPlane, "/")
+	o.AuthCacheTTL = envOpts.AuthCacheTTL
 
 	// set RunSchedules if it was not passed as a flag.
 	if o.RunSchedules == nil {

--- a/server/coordinator/coordinator.go
+++ b/server/coordinator/coordinator.go
@@ -91,7 +91,7 @@ func (c *Coordinator) SetupHandlers() (*vk.Router, error) {
 	router.Before(scopeMiddleware)
 
 	if c.opts.AdminEnabled() {
-		router.POST("/name/:ident/:namespace/:name", auth.AuthorizationMiddleware(http.DefaultClient, c.opts.ControlPlane, c.vkHandlerForModuleByName()))
+		router.POST("/name/:ident/:namespace/:name", auth.AuthorizationMiddleware(c.opts, c.vkHandlerForModuleByName()))
 	} else {
 		router.POST("/name/:ident/:namespace/:name", c.vkHandlerForModuleByName())
 		router.POST("/ref/:ref", c.vkHandlerForModuleByRef())


### PR DESCRIPTION

without fix:  1.40s user 2.10s system 8% cpu 40.612 total
```bash
time (repeat 500 { curl -s -X POST  -H "Authorization: Bearer ${SUPER_CLIENT_TOKEN}" -d "hello"  http://localhost:8080/name/${IDENTIFIER}/default/${FUNCTION} > /dev/null})
( repeat 500; do; curl -s -X POST -H  -d "hello"  > /dev/null; done; )  1.40s user 2.10s system 8% cpu 40.612 total
```


With fix: 0.96s user 1.49s system 54% cpu 4.522 total
```bash
time (repeat 500 { curl -s -X POST  -H "Authorization: Bearer ${SUPER_CLIENT_TOKEN}" -d "hello"  http://localhost:8080/name/${IDENTIFIER}/default/${FUNCTION} > /dev/null})
( repeat 500; do; curl -s -X POST -H  -d "hello"  > /dev/null; done; )  0.96s user 1.49s system 54% cpu 4.522 total
```

Currently each request that comes in requires an additional trip to the control plane to validate the incoming access token and authorize access to the requested module. 

This gets very expensive very quickly both in terms of e2e latency and resource utilization. 

This PR provides the Coordinator with a cache which stores the results of authorization requests up to 10 minutes (configurable). 

When a request comes in for a module/access key pair that is unknown a request is dispatched to the control plane. 

In the event multiple requests come in for the same key before a response has been received from the control plane the requests are parked; this ensures we only have 1 in-flight request at a time. 

Once a response has been received all currently awaiting requests are notified and may proceed accordingly. 