### PR TITLE
chore: Update CI to Go 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45
+          version: latest
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
           cache: true
       - run: go mod download
 
@@ -58,7 +58,7 @@ jobs:
     needs: [test, image, lint]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/goreleaser/goreleaser-cross:v1.18
+      image: ghcr.io/goreleaser/goreleaser-cross:v1.19
 
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 as builder
+FROM golang:1.19 as builder
 
 RUN mkdir -p /go/src/github.com/suborbital/e2core
 WORKDIR /go/src/github.com/suborbital/e2core/
@@ -16,7 +16,7 @@ RUN make e2core/static
 FROM debian:buster-slim
 
 RUN groupadd -g 999 e2core && \
-    useradd -r -u 999 -g e2core e2core && \
+	useradd -r -u 999 -g e2core e2core && \
 	mkdir -p /home/e2core && \
 	chown -R e2core /home/e2core && \
 	chmod -R 700 /home/e2core


### PR DESCRIPTION
The Go mods file shows this as a 1.19, but we don't test builds or build
artifcates (binaries and containers) on 1.19.

This commit changes that.

Also updates `golangci-lint` to latest to ensure that it gets 1.19 support. 