### PR TITLE
chore: Use Go version from gomods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version-file: go.mod
+          cache: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -28,8 +29,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version-file: go.mod
           cache: true
+
       - run: go mod download
 
       - name: Build

--- a/ops/Dockerfile-gci
+++ b/ops/Dockerfile-gci
@@ -1,4 +1,4 @@
-FROM golang:1.19.2
+FROM golang:1.19
 
 RUN ["go",  "install", "github.com/daixiang0/gci@v0.8.2"]
 


### PR DESCRIPTION
Uses the Go version describe in the Go modules file instead of whatever is in the workflow.

Also enables the built in caching to setup-go.