### PR TITLE
chore: Use built in lint fix

### DIFF
--- a/docker-compose-util.yaml
+++ b/docker-compose-util.yaml
@@ -10,10 +10,8 @@ services:
 
   lintfixer:
     container_name: "e2core_lintfixer"
-    build:
-      context: .
-      dockerfile: ./ops/Dockerfile-gci
+    image: "golangci/golangci-lint:v1.50.1-alpine"
     volumes:
-      - .:/app:rw
+      - .:/app
     working_dir: /app
-    command: ./ops/gci.sh
+    command: golangci-lint run -v --fix ./...

--- a/ops/Dockerfile-gci
+++ b/ops/Dockerfile-gci
@@ -1,5 +1,0 @@
-FROM golang:1.19
-
-RUN ["go",  "install", "github.com/daixiang0/gci@v0.8.2"]
-
-CMD gci

--- a/ops/gci.sh
+++ b/ops/gci.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-gci write -s Standard -s Default -s "Prefix(github.com/suborbital)" $(find {bus,command,common,e2core,fqfn,options,sat,scheduler,server,signaler,syncer}/ -type f -name '*.go')

--- a/sat/Makefile
+++ b/sat/Makefile
@@ -48,12 +48,6 @@ constd/metal/otel/collector: constd
 	ATMO_TRACER_PROBABILITY=${ATMO_TRACER_PROBABILITY} \
 	CONSTD_EXEC_MODE=metal .bin/constd $(PWD)/constd/example-project/runnables.wasm.zip
 
-lint:
-	docker compose up linter
-
-importfix:
-	docker compose up lintfixer
-
 runlocal:
 	SAT_METRICS_OTEL_ENDPOINT=localhost:4317 \
 	SAT_METRICS_TYPE=otel \

--- a/sat/docker-compose.yaml
+++ b/sat/docker-compose.yaml
@@ -38,25 +38,5 @@ services:
       - ./otel-config.yaml:/etc/otel/config.yaml:ro
       - ./traces:/traces:rw
 
-  linter:
-    container_name: "sat_linter"
-    image: "golangci/golangci-lint:v1.45.2-alpine"
-    volumes:
-      - .:/app
-      - vendor:/app/vendor/
-    working_dir: /app
-    command: golangci-lint run ./...
-
-  lintfixer:
-    container_name: "sat_lintfixer"
-    build:
-      context: .
-      dockerfile: ./ops/Dockerfile-gci
-    volumes:
-      - .:/app:rw
-      - vendor:/app/vendor/
-    working_dir: /app
-    command: ./ops/gci.sh
-
 volumes:
   vendor:

--- a/sat/ops/Dockerfile-gci
+++ b/sat/ops/Dockerfile-gci
@@ -1,5 +1,0 @@
-FROM golang:1.18
-
-RUN ["go",  "install", "github.com/daixiang0/gci@v0.3.3"]
-
-CMD gci

--- a/sat/ops/gci.sh
+++ b/sat/ops/gci.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-gci write -s Standard -s Default -s "Prefix(github.com/suborbital)" -s "Prefix(github.com/suborbital/e2core/sat)" --NoInlineComments --NoPrefixComments main.go $(find {sat,constd}/ -type f -name '*.go')


### PR DESCRIPTION
golangci-lint can fix gci lint errors, and others.
