### PR TITLE
chore: Use the setup-go cache over golangci-lint cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
+          skip-cache: true
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should use the cache with the same ID as other jobs, rather than storing a similar one under the golang action.