### PR TITLE
chore: Add CMD to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,3 +30,4 @@ COPY --from=builder /go/src/github.com/suborbital/e2core/.bin/e2core /usr/local/
 WORKDIR /home/e2core
 
 USER e2core
+CMD ["/usr/local/bin/e2core", "start"]


### PR DESCRIPTION
Adds a CMD stanza to the Dockerfile which ensures that Docker will start
the container with these arguments by default if not provided/overrode
by other runtimes (Kuberntes, compose, etc).
