### PR TITLE
chore: Disable otel updates for both otel, otel-contrib

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,11 @@
   ignorePaths: ["example-project/**"],
   packageRules: [
     {
-      extends: "monorepo:opentelemetry-go",
+      matchSourceUrls: [
+        "https://github.com/open-telemetry/opentelemetry-go",
+        "https://github.com/open-telemetry/opentelemetry-go-contrib",
+      ],
+      groupName: "opentelemetry-go monorepo",
       enabled: false,
     },
   ],


### PR DESCRIPTION
Previously only disabled mainline otel updates. This commit disables updates from contrib as well.

Related to #291