### PR TITLE
chore: Release v0.5.1

### DIFF
--- a/.subo.yml
+++ b/.subo.yml
@@ -1,5 +1,5 @@
 dotVersionFiles:
-  - server/release/version.go
+  - e2core/release/version.go
 
 preMakeTargets:
   - build

--- a/changelogs/v0.5.1.md
+++ b/changelogs/v0.5.1.md
@@ -1,0 +1,1 @@
+E2Core Beta-5.1 adds command to the Docker image, allowing the container to start in server mode by default.

--- a/e2core/release/version.go
+++ b/e2core/release/version.go
@@ -1,4 +1,4 @@
 package release
 
 // E2CoreServerDotVersion represents the dot version for E2Core Server
-var E2CoreServerDotVersion = "0.5.0"
+var E2CoreServerDotVersion = "0.5.1"


### PR DESCRIPTION
E2Core Beta-5.1 adds command to the Docker image, allowing the container to start in server mode by default.

https://github.com/suborbital/e2core/compare/v0.5.0...rc-v0.5.1