### PR TITLE
feat: Update vektor and systemspec

### DIFF
--- a/e2core/auth/access.go
+++ b/e2core/auth/access.go
@@ -23,20 +23,20 @@ type TenantInfo struct {
 
 func AuthorizationMiddleware(opts *options.Options, inner vk.HandlerFunc) vk.HandlerFunc {
 	authorizer := NewApiAuthClient(opts)
-	return func(req *http.Request, ctx *vk.Ctx) (interface{}, error) {
+	return func(w http.ResponseWriter, r *http.Request, ctx *vk.Ctx) error {
 		identifier := ctx.Params.ByName("ident")
 		namespace := ctx.Params.ByName("namespace")
 		name := ctx.Params.ByName("name")
 
-		tntInfo, err := authorizer.Authorize(ExtractAccessToken(req.Header), identifier, namespace, name)
+		tntInfo, err := authorizer.Authorize(ExtractAccessToken(r.Header), identifier, namespace, name)
 		if err != nil {
 			ctx.Log.Error(err)
-			return vk.R(http.StatusUnauthorized, ""), nil
+			return vk.E(http.StatusUnauthorized, "")
 		}
 
 		ctx.Set("ident", fmt.Sprintf("%s.%s", tntInfo.Environment, tntInfo.Tenant))
 
-		return inner(req, ctx)
+		return inner(w, r, ctx)
 	}
 }
 

--- a/e2core/coordinator/coordinator_headlessauth.go
+++ b/e2core/coordinator/coordinator_headlessauth.go
@@ -8,38 +8,39 @@ import (
 
 // nolint
 func (c *Coordinator) authMiddleware() vk.Middleware {
-	return func(r *http.Request, ctx *vk.Ctx) error {
-		if c.opts.EnvironmentToken != "" {
-			return nil
-		} else {
+	return func(inner vk.HandlerFunc) vk.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request, ctx *vk.Ctx) error {
+			if c.opts.EnvironmentToken != "" {
+				return inner(w, r, ctx)
+			}
+
 			return vk.E(http.StatusUnauthorized, "unauthorized")
+
+			// TODO: restore the ability to have dynamic auth
+
+			// FQMN, err := fqmn.FromURL(r.URL)
+			// if err != nil {
+			// 	ctx.Log.Debug(errors.Wrap(err, "failed to fqmn.FromURL, skipping headless auth"))
+			// 	return nil
+			// }
+
+			// auth := r.Header.Get("Authorization")
+
+			// // we call GetModule, which by now should have the module cached, so it'll be fast.
+			// module, err := c.App.GetModule(FQMN)
+			// if err != nil {
+			// 	ctx.Log.Error(errors.Wrap(err, "failed to GetModule"))
+			// 	return vk.E(http.StatusBadRequest, "invalid FQMN URI")
+			// }
+
+			// if len(module.TokenHash) > 0 {
+			// 	providedHash := system source.TokenHash(auth)
+
+			// 	if subtle.ConstantTimeCompare(module.TokenHash, providedHash) != 1 {
+			// 		ctx.Log.Error(errors.New("provided authorization header does not match module's token hash"))
+			// 		return vk.E(http.StatusUnauthorized, "unauthorized")
+			// 	}
+			// }
 		}
-
-		// TODO: restore the ability to have dynamic auth
-		// FQMN, err := fqmn.FromURL(r.URL)
-		// if err != nil {
-		// 	ctx.Log.Debug(errors.Wrap(err, "failed to fqmn.FromURL, skipping headless auth"))
-		// 	return nil
-		// }
-
-		// auth := r.Header.Get("Authorization")
-
-		// // we call GetModule, which by now should have the module cached, so it'll be fast.
-		// module, err := c.App.GetModule(FQMN)
-		// if err != nil {
-		// 	ctx.Log.Error(errors.Wrap(err, "failed to GetModule"))
-		// 	return vk.E(http.StatusBadRequest, "invalid FQMN URI")
-		// }
-
-		// if len(module.TokenHash) > 0 {
-		// 	providedHash := system source.TokenHash(auth)
-
-		// 	if subtle.ConstantTimeCompare(module.TokenHash, providedHash) != 1 {
-		// 		ctx.Log.Error(errors.New("provided authorization header does not match module's token hash"))
-		// 		return vk.E(http.StatusUnauthorized, "unauthorized")
-		// 	}
-		// }
-
-		return nil
 	}
 }

--- a/e2core/coordinator/health.go
+++ b/e2core/coordinator/health.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (c *Coordinator) health() vk.HandlerFunc {
-	return func(request *http.Request, ctx *vk.Ctx) (interface{}, error) {
-		return map[string]bool{"healthy": true}, nil
+	return func(w http.ResponseWriter, r *http.Request, ctx *vk.Ctx) error {
+		return vk.RespondJSON(ctx.Context, w, map[string]bool{"healthy": true}, http.StatusOK)
 	}
 }

--- a/e2core/coordinator/metrics.go
+++ b/e2core/coordinator/metrics.go
@@ -14,17 +14,17 @@ type MetricsResponse struct {
 }
 
 func (c *Coordinator) metricsHandler() vk.HandlerFunc {
-	return func(r *http.Request, ctx *vk.Ctx) (interface{}, error) {
+	return func(w http.ResponseWriter, r *http.Request, ctx *vk.Ctx) error {
 		metrics, err := c.exec.Metrics()
 		if err != nil {
 			ctx.Log.Error(errors.Wrap(err, "failed to exec.Metrics"))
-			return nil, vk.E(http.StatusInternalServerError, "unknown error")
+			return vk.E(http.StatusInternalServerError, "unknown error")
 		}
 
 		resp := &MetricsResponse{
 			Scheduler: *metrics,
 		}
 
-		return resp, nil
+		return vk.RespondJSON(ctx.Context, w, resp, http.StatusOK)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
 	github.com/suborbital/go-kit v0.0.3
-	github.com/suborbital/systemspec v0.0.4
-	github.com/suborbital/vektor v0.5.3
+	github.com/suborbital/systemspec v0.0.5
+	github.com/suborbital/vektor v0.6.1
 	github.com/testcontainers/testcontainers-go v0.13.0
 	github.com/twmb/franz-go v1.9.1
 	github.com/wasmerio/wasmer-go v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -761,10 +761,10 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/suborbital/go-kit v0.0.3 h1:J3KwNZYZDff+jNwqnmHJNrOgM/IHNwbJj7yThh1CU5o=
 github.com/suborbital/go-kit v0.0.3/go.mod h1:BgsNga5S7b7/G8WHUa2KRupMcILULhDqEYIUxZtB/d0=
-github.com/suborbital/systemspec v0.0.4 h1:fwHef+6yyRVL7brODYuaF+kGhhCc3sx33L2ftiwAsuo=
-github.com/suborbital/systemspec v0.0.4/go.mod h1:qmx2yrqbxf8OSiIo/8Pu/aRvn12emPDbCtCEG+MfXa0=
-github.com/suborbital/vektor v0.5.3 h1:gtdcRydR35WIrIA5PpSiDE/x5mOGvM2loIMDe0PwwZg=
-github.com/suborbital/vektor v0.5.3/go.mod h1:/OSnPYtTDFwGHnoFaBYpWQu1moH1X8Vo/y4BVU3+oWM=
+github.com/suborbital/systemspec v0.0.5 h1:GLsgWa+hi9M8Swq3wmmKXhdTUZSSggYO95gS+Yp6xzE=
+github.com/suborbital/systemspec v0.0.5/go.mod h1:mM5aE5n6gfEEFOLc9FtfpOnEzcJJpdLeb//IayVoJKo=
+github.com/suborbital/vektor v0.6.1 h1:Goh/274fy03WVleUrbqq4+6Q+B+B3zuQLmm9blqNn3M=
+github.com/suborbital/vektor v0.6.1/go.mod h1:TpoxB7PN6CRnhG9J6JDElxXG7vVkbJsvLEOzbJdJ2+4=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/sat/sat/worker_metrics.go
+++ b/sat/sat/worker_metrics.go
@@ -14,17 +14,17 @@ type WorkerMetricsResponse struct {
 }
 
 func (s *Sat) workerMetricsHandler() vk.HandlerFunc {
-	return func(r *http.Request, ctx *vk.Ctx) (interface{}, error) {
+	return func(w http.ResponseWriter, r *http.Request, ctx *vk.Ctx) error {
 		metrics, err := s.exec.Metrics()
 		if err != nil {
 			ctx.Log.Error(errors.Wrap(err, "failed to exec.Metrics"))
-			return nil, vk.E(http.StatusInternalServerError, "unknown error")
+			return vk.E(http.StatusInternalServerError, "unknown error")
 		}
 
 		resp := &WorkerMetricsResponse{
 			Scheduler: *metrics,
 		}
 
-		return resp, nil
+		return vk.RespondJSON(ctx.Context, w, resp, http.StatusOK)
 	}
 }


### PR DESCRIPTION
Updates vektor to v0.6.1

- Updates Middleware to be wrappable
- Updates handlers for new function signatures
- Replaces `vk.R` with `vk.RepondJSON` or `vk.RepondBytes`