### PR TITLE
fix: Bring back capability to enable multi-tenant mode

### DIFF
--- a/e2core/auth/access.go
+++ b/e2core/auth/access.go
@@ -8,10 +8,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/suborbital/e2core/e2core/options"
-	"github.com/suborbital/e2core/foundation/common"
 	"github.com/suborbital/systemspec/system"
 	"github.com/suborbital/vektor/vk"
+
+	"github.com/suborbital/e2core/e2core/options"
+	"github.com/suborbital/e2core/foundation/common"
 )
 
 type TenantInfo struct {
@@ -34,7 +35,7 @@ func AuthorizationMiddleware(opts *options.Options, inner vk.HandlerFunc) vk.Han
 			return vk.E(http.StatusUnauthorized, "")
 		}
 
-		ctx.Set("ident", fmt.Sprintf("%s.%s", tntInfo.Environment, tntInfo.Tenant))
+		ctx.Set("ident", tntInfo.Tenant)
 
 		return inner(w, r, ctx)
 	}

--- a/e2core/auth/access.go
+++ b/e2core/auth/access.go
@@ -8,11 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/suborbital/systemspec/system"
-	"github.com/suborbital/vektor/vk"
-
 	"github.com/suborbital/e2core/e2core/options"
 	"github.com/suborbital/e2core/foundation/common"
+	"github.com/suborbital/systemspec/system"
+	"github.com/suborbital/vektor/vk"
 )
 
 type TenantInfo struct {

--- a/e2core/server/server.go
+++ b/e2core/server/server.go
@@ -7,12 +7,14 @@ import (
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
+	"github.com/suborbital/vektor/vk"
+
+	"github.com/suborbital/e2core/e2core/auth"
 	"github.com/suborbital/e2core/e2core/options"
 	"github.com/suborbital/e2core/e2core/syncer"
 	"github.com/suborbital/e2core/foundation/bus/bus"
 	"github.com/suborbital/e2core/foundation/bus/discovery/local"
 	"github.com/suborbital/e2core/foundation/bus/transport/websocket"
-	"github.com/suborbital/vektor/vk"
 )
 
 const E2CoreHealthURI = "/health"
@@ -75,10 +77,14 @@ func New(sync *syncer.Syncer, opts *options.Options) (*Server, error) {
 
 	router.WithMiddlewares(server.openTelemetryMiddleware())
 	router.WithMiddlewares(scopeMiddleware)
+	if opts.AdminEnabled() {
+		router.POST("/name/:ident/:namespace/:name", auth.AuthorizationMiddleware(opts, server.executePluginByNameHandler()))
+	} else {
+		router.POST("/name/:ident/:namespace/:name", server.executePluginByNameHandler())
+		router.POST("/ref/:ref", server.executePluginByRefHandler())
+		router.POST("/workflow/:ident/:namespace/:name", server.executeWorkflowHandler())
+	}
 
-	router.POST("/name/:ident/:namespace/:name", server.executePluginByNameHandler())
-	router.POST("/ref/:ref", server.executePluginByRefHandler())
-	router.POST("/workflow/:ident/:namespace/:name", server.executeWorkflowHandler())
 	router.GET("/health", server.healthHandler())
 
 	server.server.SwapRouter(router)

--- a/e2core/server/server.go
+++ b/e2core/server/server.go
@@ -7,14 +7,13 @@ import (
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
-	"github.com/suborbital/vektor/vk"
-
 	"github.com/suborbital/e2core/e2core/auth"
 	"github.com/suborbital/e2core/e2core/options"
 	"github.com/suborbital/e2core/e2core/syncer"
 	"github.com/suborbital/e2core/foundation/bus/bus"
 	"github.com/suborbital/e2core/foundation/bus/discovery/local"
 	"github.com/suborbital/e2core/foundation/bus/transport/websocket"
+	"github.com/suborbital/vektor/vk"
 )
 
 const E2CoreHealthURI = "/health"


### PR DESCRIPTION
The hosted Admin feature flag logic was lost during the refactor, this PR brings it back.

There was also a small change to the tenant identifier format which removes the requirement of an environment prefix which is now reflected in the authorizer code. 

Future work: Add reverse look up from ref to plugin for admin enabled e2 core.