### PR TITLE
fix(auth): tenant api now hosted on api service

### DIFF
--- a/e2core/auth/access.go
+++ b/e2core/auth/access.go
@@ -46,7 +46,7 @@ func NewApiAuthClient(opts *options.Options) *AuthzClient {
 			Timeout:   20 * time.Second,
 			Transport: http.DefaultTransport,
 		},
-		location: opts.ControlPlane + "/api/v2/tenant/%s",
+		location: opts.ControlPlane + "/api/v1/tenant/%s",
 		cache:    NewAuthorizationCache(opts.AuthCacheTTL),
 	}
 }


### PR DESCRIPTION
See also https://github.com/suborbital/se2/pull/1028