### PR TITLE
chore: Build binaries with gorelease on each commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,32 +38,37 @@ jobs:
       - run: make e2core/static
       - run: make test/ci
 
+  bin:
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/goreleaser/goreleaser-cross:v1.20.0
+
+    steps:
+      - uses: actions/checkout@v3
+      # temporary work around for https://github.com/actions/checkout/issues/1169
+      - run: git config --system --add safe.directory /__w/e2core/e2core
+
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          version: latest
+          install-only: true
+
+      - if: startsWith(github.ref, 'refs/tags/v')
+        run: goreleaser release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: goreleaser release --clean --snapshot
+
   image:
-    needs: [test, lint]
+    needs: [lint, test]
     runs-on: ubuntu-latest
 
     steps:
       - uses: docker/setup-buildx-action@v2
       - uses: docker/setup-qemu-action@v2
-
-      - uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/metadata-action@v4
-        id: docker_meta
-        with:
-          images: suborbital/e2core,ghcr.io/suborbital/e2core
-          tags: |
-            type=match,pattern=(v.*)
-          flavor: |
-            latest=auto
 
       - name: Build e2core image
         uses: docker/build-push-action@v4
@@ -74,8 +79,30 @@ jobs:
           tags: suborbital/e2core:dev
       - run: docker run --rm suborbital/e2core:dev /usr/local/bin/e2core -v
 
+      - if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v4
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: docker_meta
+        with:
+          images: suborbital/e2core,ghcr.io/suborbital/e2core
+          tags: |
+            type=match,pattern=(v.*)
+          flavor: |
+            latest=auto
+
       - name: Build and push e2core image
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/build-push-action@v4
         with:
           cache-from: type=gha
@@ -84,21 +111,3 @@ jobs:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-
-  release-bin:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [test, lint]
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/goreleaser/goreleaser-cross:v1.20
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+project_name: e2core
 env:
   - CGO_ENABLED=1
 builds:


### PR DESCRIPTION
Builds the binary on each commit, and only pushes artifacts on releases.