### PR TITLE
fix(e2core): Replace syscall

### DIFF
--- a/docker-compose-util.yaml
+++ b/docker-compose-util.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 services:
   linter:
     container_name: "e2core_linter"
-    image: "golangci/golangci-lint:v1.50.1-alpine"
+    image: "golangci/golangci-lint:v1.52-alpine"
     volumes:
       - .:/app
     working_dir: /app
@@ -10,7 +10,7 @@ services:
 
   lintfixer:
     container_name: "e2core_lintfixer"
-    image: "golangci/golangci-lint:v1.50.1-alpine"
+    image: "golangci/golangci-lint:v1.52-alpine"
     volumes:
       - .:/app
     working_dir: /app

--- a/e2core/backend/satbackend/command.go
+++ b/e2core/backend/satbackend/command.go
@@ -12,13 +12,18 @@ import (
 )
 
 // modStartCommand returns the command and the port string
-func modStartCommand(module tenant.Module) (string, string) {
+func modStartCommand(module tenant.Module) ([]string, string) {
 	port, err := randPort()
 	if err != nil {
 		log.Fatal(errors.Wrap(err, "failed to randPort"))
 	}
 
-	cmd := fmt.Sprintf("e2core mod start %s", module.FQMN)
+	cmd := []string{
+		"e2core",
+		"mod",
+		"start",
+		module.FQMN,
+	}
 
 	return cmd, port
 }

--- a/e2core/backend/satbackend/orchestrator.go
+++ b/e2core/backend/satbackend/orchestrator.go
@@ -70,10 +70,7 @@ loop:
 
 	for _, s := range o.sats {
 		ll.Debug().Str("satFQMN", s.fqmn).Msg("terminating sat instance")
-		err := s.terminate()
-		if err != nil {
-			ll.Fatal().Str("satFQMN", s.fqmn).Err(err).Msg("terminating sats failed")
-		}
+		s.terminate()
 	}
 
 	o.wg.Done()
@@ -140,19 +137,18 @@ func (o *Orchestrator) reconcileConstellation(syncer *syncer.Syncer) {
 				}
 
 				// repeat forever in case the command does error out
-				uuid, pid, err := exec.Run(
+				processUUID, cxl, err := exec.Run(
 					cmd,
 					"SAT_HTTP_PORT="+port,
 					"SAT_CONTROL_PLANE="+o.opts.ControlPlane,
 					"SAT_CONNECTIONS="+connectionsEnv,
 				)
-
 				if err != nil {
 					ll.Err(err).Str("moduleFQMN", module.FQMN).Msg("exec.Run failed for sat instance")
 					return
 				}
 
-				satWatcher.add(module.FQMN, port, uuid, pid)
+				satWatcher.add(module.FQMN, port, processUUID, cxl)
 
 				ll.Debug().Str("moduleFQMN", module.FQMN).Str("port", port).Msg("successfully started sat")
 			}


### PR DESCRIPTION
Closes #426 

Syscall is dead, long live exec! I also vastly simplified the way creating subprocesses work. At a glance:

* instead of `syscall.ForkExec`, the way to start is `cmd.Start()`, which will asynchronously start a configured command
* no need for `syscall.procinfo`, because everything else was already assigned to the properties of the command struct
* no need to keep track of process ids, because the `exec.CommandWithContext` gets a context which has a cancel function with cause
* the terminate and scale down functionalities merely call the cancel functions for the running processes, which do not return errors. It is implied that everything will just work because we've moved the responsibility of keeping track of shutdown and whatnot to the go standard library

`syscall` package however remains in use, but it's constrained to the `signal.Notify` functionality. The `os` package only provides `os.Interrupt` and `os.Kill` because [those two are the only ones that are present across architectures](https://pkg.go.dev/os#Signal). `syscall.SIGTERM`, one of the signals we're listening to, is not.

The suggestion is to [use the appropriate `x/sys` package](https://pkg.go.dev/golang.org/x/sys@v0.7.0), which is either `/unix` or `/windows`, however looking at [unix's sigterm definition, it's still `syscall.Signal(0xf)`](https://cs.opensource.google/go/x/sys/+/refs/tags/v0.7.0:unix/zerrors_linux.go;l=3477), which is the [same as `syscall.SIGTERM`](https://cs.opensource.google/go/go/+/refs/tags/go1.20.4:src/syscall/zerrors_linux_amd64.go;l=1343).