### PR TITLE
fix(e2core): Deal with dead processes

### DIFF
--- a/e2core/backend/satbackend/exec/exec.go
+++ b/e2core/backend/satbackend/exec/exec.go
@@ -11,9 +11,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+type WaitFunc func() error
+
 // Run runs a command, outputting to terminal and returning the full output and/or error
 // a channel is returned which, when sent on, will terminate the process that was started
-func Run(cmd []string, env ...string) (string, context.CancelCauseFunc, error) {
+func Run(cmd []string, env ...string) (string, context.CancelCauseFunc, WaitFunc, error) {
 	procUUID := uuid.New().String()
 	uuidEnv := fmt.Sprintf("%s_UUID=%s", strings.ToUpper(cmd[0]), procUUID)
 	env = append(env, uuidEnv)
@@ -31,10 +33,10 @@ func Run(cmd []string, env ...string) (string, context.CancelCauseFunc, error) {
 
 	err := command.Start()
 	if err != nil {
-		return "", nil, errors.Wrap(err, "command.Start()")
+		return "", nil, nil, errors.Wrap(err, "command.Start()")
 	}
 
-	return procUUID, cxl, nil
+	return procUUID, cxl, command.Wait, nil
 }
 
 // this is unused but we may want to do logging-to-speficig-directory some time in the

--- a/e2core/backend/satbackend/orchestrator.go
+++ b/e2core/backend/satbackend/orchestrator.go
@@ -166,7 +166,7 @@ func (o *Orchestrator) reconcileConstellation(syncer *syncer.Syncer) {
 
 					err = satWatcher.addDied(port)
 					if err != nil {
-						ll.Err(err).Str("moduleFQMN", module.FQMN).Str("port", port).Msg("adding the port to the died list thing")
+						ll.Err(err).Str("moduleFQMN", module.FQMN).Str("port", port).Msg("adding the port to the died list")
 					}
 
 					ll.Info().Str("moduleFQMN", module.FQMN).Str("port", port).Msg("sent died message into channel")

--- a/e2core/backend/satbackend/orchestrator.go
+++ b/e2core/backend/satbackend/orchestrator.go
@@ -126,15 +126,12 @@ func (o *Orchestrator) reconcileConstellation(syncer *syncer.Syncer) {
 
 			satWatcher := o.sats[module.FQMN]
 
-			ll.Info().Msg("starting the range over the things in the died channel")
-
-			satWatcher.diedListLock.Lock()
-			for diedPort := range satWatcher.diedList {
-				_ = satWatcher.terminateInstance(diedPort)
+			satWatcher.deadListLock.Lock()
+			for deadPort := range satWatcher.deadList {
+				_ = satWatcher.terminateInstance(deadPort)
 			}
-			satWatcher.diedList = make(map[string]struct{})
-			satWatcher.diedListLock.Unlock()
-			ll.Info().Msg("no more things, continuing reconciliation")
+			satWatcher.deadList = make(map[string]struct{})
+			satWatcher.deadListLock.Unlock()
 
 			launch := func() {
 				cmd, port := modStartCommand(module)
@@ -164,12 +161,12 @@ func (o *Orchestrator) reconcileConstellation(syncer *syncer.Syncer) {
 						ll.Err(err).Str("moduleFQMN", module.FQMN).Str("port", port).Msg("calling waitfunc for the module failed")
 					}
 
-					err = satWatcher.addDied(port)
+					err = satWatcher.addToDead(port)
 					if err != nil {
-						ll.Err(err).Str("moduleFQMN", module.FQMN).Str("port", port).Msg("adding the port to the died list")
+						ll.Err(err).Str("moduleFQMN", module.FQMN).Str("port", port).Msg("adding the port to the dead list")
 					}
 
-					ll.Info().Str("moduleFQMN", module.FQMN).Str("port", port).Msg("sent died message into channel")
+					ll.Info().Str("moduleFQMN", module.FQMN).Str("port", port).Msg("added port to dead list")
 				}()
 
 				satWatcher.add(module.FQMN, port, processUUID, cxl)

--- a/e2core/backend/satbackend/watcher.go
+++ b/e2core/backend/satbackend/watcher.go
@@ -32,8 +32,8 @@ type watcher struct {
 	fqmn             string
 	instances        map[string]*instance
 	log              zerolog.Logger
-	diedList         map[string]struct{}
-	diedListLock     sync.RWMutex
+	deadList         map[string]struct{}
+	deadListLock     sync.RWMutex
 	instancesRunning sync.WaitGroup
 }
 
@@ -56,22 +56,22 @@ func newWatcher(fqmn string, log zerolog.Logger) *watcher {
 		fqmn:             fqmn,
 		instances:        map[string]*instance{},
 		log:              log.With().Str("module", "watcher").Logger(),
-		diedList:         make(map[string]struct{}),
-		diedListLock:     sync.RWMutex{},
+		deadList:         make(map[string]struct{}),
+		deadListLock:     sync.RWMutex{},
 		instancesRunning: sync.WaitGroup{},
 	}
 }
 
-func (w *watcher) addDied(port string) error {
-	w.diedListLock.Lock()
-	defer w.diedListLock.Unlock()
+func (w *watcher) addToDead(port string) error {
+	w.deadListLock.Lock()
+	defer w.deadListLock.Unlock()
 
-	_, ok := w.diedList[port]
+	_, ok := w.deadList[port]
 	if ok {
-		return errors.New("port is already in the died list")
+		return errors.New("port is already in the dead list")
 	}
 
-	w.diedList[port] = struct{}{}
+	w.deadList[port] = struct{}{}
 	return nil
 }
 

--- a/e2core/backend/satbackend/watcher.go
+++ b/e2core/backend/satbackend/watcher.go
@@ -82,7 +82,7 @@ func (w *watcher) add(fqmn, port, uuid string, cxl context.CancelCauseFunc) {
 
 	i, ok := w.instances[port]
 	if ok {
-		w.log.Error().Str("port", port).Str("fqmn", fqmn).Str("uuid", uuid).Any("exising", i).Msg("!!!! Something already exists on this port !!!!")
+		w.log.Error().Str("port", port).Str("fqmn", fqmn).Str("uuid", uuid).Any("existing", i).Msg("omething already exists on this port")
 	}
 
 	w.instances[port] = &instance{


### PR DESCRIPTION
Related to #426 

This is a quality of life improvement that deals with crashed processes and recovery.

When using the `command.Start()` function call, the process starts in the background. We're supposed to use the `command.Wait()` to determine when either the process finished, or exited for some other reason.

This changeset accommodates collecting the wait functions, starts them for each sub process, and when they unblock, their ports are added to a `died` map, which will then be  removed automatically from watcher's bookkeeping.

I've tested this manually by:
1. creating an image for `e2core` using `make docker/dev`
2. starting up everything with se2's `docker compose up` (this is internal)
3. start following the logs with `docker compose logs e2core --follow` (this is internal)
4. making sure that I can execute an existing function
5. hopping into the e2core docker container with `docker exec -i -t a063f35d5c2b /bin/bash` where the `a06...` is the image ID you get if you list the images with `docker ps` for e2core
6. once inside, listing the process IDs with `ls -l /proc/*/exe`, which will have a similar output:
   ```
   lrwxrwxrwx 1 e2core e2core 0 May  3 17:20 /proc/1/exe -> /usr/local/bin/e2core
   lrwxrwxrwx 1 e2core e2core 0 May  3 17:21 /proc/16/exe -> /usr/local/bin/e2core
   lrwxrwxrwx 1 e2core e2core 0 May  3 17:31 /proc/38/exe -> /bin/bash
   lrwxrwxrwx 1 e2core e2core 0 May  3 17:33 /proc/self/exe -> /bin/ls
   lrwxrwxrwx 1 e2core e2core 0 May  3 17:33 /proc/thread-self/exe -> /bin/ls
   ```
7. of those, the second e2core is the sub process with process id 16
8. `kill -9 16` to terminate that
9. look at the logs to see that the termination and reaping of instance was completed and a new one was started during reconcile step
10. check again that I can execute the same function by sending the post request to the local edge endpoint

