### PR TITLE
fix(e2core): Add the panic recovery middleware to our echoes

### DIFF
--- a/e2core/server/server.go
+++ b/e2core/server/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho"
@@ -58,6 +59,7 @@ func New(l zerolog.Logger, sync *syncer.Syncer, opts *options.Options) (*Server,
 	e.Use(
 		mid.UUIDRequestID(),
 		otelecho.Middleware("e2core"),
+		middleware.Recover(),
 	)
 
 	d := newDispatcher(ll, b.Connect())

--- a/e2core/sourceserver/bundle.go
+++ b/e2core/sourceserver/bundle.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 
@@ -30,6 +31,7 @@ func FromBundle(bundlePath string) (*echo.Echo, error) {
 	e.Use(
 		mid.UUIDRequestID(),
 		mid.Logger(l, nil),
+		middleware.Recover(),
 	)
 
 	rt := NewRouter(l, bs)

--- a/sat/sat/sat.go
+++ b/sat/sat/sat.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/trace"
@@ -73,6 +74,9 @@ func New(config *Config, logger zerolog.Logger, traceProvider trace.TracerProvid
 	}
 
 	sat.server = echo.New()
+	sat.server.Use(
+		middleware.Recover(),
+	)
 	sat.server.HTTPErrorHandler = kitError.Handler(logger)
 	sat.server.HideBanner = true
 


### PR DESCRIPTION
No issue

If we panic at any point when creating a new instance, this middleware should recover it